### PR TITLE
chore: use new license specification inside pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ authors = [
 maintainers = [
     {email = "iddohau@gmail.com", name = "Iddo Hauschner"},
 ]
-license = {file = "LICENSE.txt"}
+license = "MIT"
+license-files = ["LICENSE.txt"]
 readme = "README.md"
 requires-python = ">=3.10"
 homepage = "https://github.com/iddohau/rust-strings"


### PR DESCRIPTION
Hi :wave: 

I open a PR to update the `pyproject.toml` licensing attributes, to use the new specification, according to https://packaging.python.org/en/latest/specifications/pyproject-toml/#license.

- `license` define now a valid SPDX license expression,
- and `license-files` define an array of path to the license files.

On my side, tools like https://github.com/raimon49/pip-licenses, don't seems to find the license with the legacy specification. 